### PR TITLE
Refactor Timer usage

### DIFF
--- a/src/main/java/me/zypj/rbw/RBWPlugin.java
+++ b/src/main/java/me/zypj/rbw/RBWPlugin.java
@@ -65,19 +65,9 @@ public final class RBWPlugin extends JavaPlugin {
 
         getServer().getConsoleSender().sendMessage("[RBW] \n§e[!] Finishing up... this might take around 10 seconds\n");
 
-        new Timer().schedule(new TimerTask() {
-            @Override
-            public void run() {
-                initializeGuildAndLoadData();
-            }
-        }, 10000);
+        Bukkit.getScheduler().runTaskLater(this, this::initializeGuildAndLoadData, 20L * 10);
 
-        new Timer().scheduleAtFixedRate(new TimerTask() {
-            @Override
-            public void run() {
-                UnbanTask.checkAndUnbanPlayers();
-            }
-        }, 1000 * 60 * 60, 1000 * 60 * 60);
+        Bukkit.getScheduler().runTaskTimer(this, UnbanTask::checkAndUnbanPlayers, 20L * 60 * 60, 20L * 60 * 60);
 		
 		/*
 		Register new api

--- a/src/main/java/me/zypj/rbw/commands/game/VoidCmd.java
+++ b/src/main/java/me/zypj/rbw/commands/game/VoidCmd.java
@@ -14,8 +14,8 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 import net.dv8tion.jda.api.entities.emoji.Emoji;
 
-import java.util.Timer;
-import java.util.TimerTask;
+import me.zypj.rbw.RBWPlugin;
+import org.bukkit.Bukkit;
 
 public class VoidCmd extends Command {
     public VoidCmd(String command, String usage, String[] aliases, String description, CommandSubsystem subsystem) {
@@ -46,30 +46,24 @@ public class VoidCmd extends Command {
             message.addReaction(Emoji.fromUnicode("✔")).queue();
             message.addReaction(Emoji.fromUnicode("❌")).queue();
 
-            TimerTask task = new TimerTask() {
-                @Override
-                public void run() {
-                    Message message1 = channel.retrieveMessageById(message.getId()).complete();
+            Bukkit.getScheduler().runTaskLater(RBWPlugin.getInstance(), () -> {
+                Message message1 = channel.retrieveMessageById(message.getId()).complete();
 
-                    if (message1.getReactions().get(0).getCount() - 1 < message1.getReactions().get(1).getCount()) {
-                        Embed reply = new Embed(EmbedType.ERROR, "", "Voiding has cancelled", 1);
-                        msg.replyEmbeds(reply.build()).queue();
-                        return;
-                    }
-
-                    Embed done = new Embed(EmbedType.DEFAULT, "Game `#" + number + "` has Voided", "If this command is misused, please take a print and send it to us in a ticket channel being deleted in `60s`", 1);
-                    done.addField("Request by: ", sender.getAsMention(), false);
-                    game.setState(GameState.VOIDED);
-                    game.setScoredBy(sender);
-                    game.closeChannel(60);
-
-                    message1.editMessageEmbeds(done.build()).queue();
-                    message1.clearReactions().queue();
+                if (message1.getReactions().get(0).getCount() - 1 < message1.getReactions().get(1).getCount()) {
+                    Embed reply = new Embed(EmbedType.ERROR, "", "Voiding has cancelled", 1);
+                    msg.replyEmbeds(reply.build()).queue();
+                    return;
                 }
-            };
 
-            Timer timer = new Timer();
-            timer.schedule(task, 30000);
+                Embed done = new Embed(EmbedType.DEFAULT, "Game `#" + number + "` has Voided", "If this command is misused, please take a print and send it to us in a ticket channel being deleted in `60s`", 1);
+                done.addField("Request by: ", sender.getAsMention(), false);
+                game.setState(GameState.VOIDED);
+                game.setScoredBy(sender);
+                game.closeChannel(60);
+
+                message1.editMessageEmbeds(done.build()).queue();
+                message1.clearReactions().queue();
+            }, 20L * 30);
         });
     }
 }

--- a/src/main/java/me/zypj/rbw/commands/player/ScreenshareCmd.java
+++ b/src/main/java/me/zypj/rbw/commands/player/ScreenshareCmd.java
@@ -14,6 +14,8 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 
+import me.zypj.rbw.RBWPlugin;
+import org.bukkit.Bukkit;
 import java.util.*;
 
 public class ScreenshareCmd extends Command {
@@ -70,14 +72,9 @@ public class ScreenshareCmd extends Command {
         guild.modifyMemberRoles(target, freeze, null).queue();
 
         // Schedule unfreeze
-        long delayMillis = Integer.parseInt(Config.getValue("time-till-unfrozen")) * 60_000L;
-        Timer timer = new Timer();
-        timer.schedule(new TimerTask() {
-            @Override
-            public void run() {
-                guild.modifyMemberRoles(target, null, freeze).queue();
-            }
-        }, delayMillis);
+        long delayTicks = Integer.parseInt(Config.getValue("time-till-unfrozen")) * 60L * 20L;
+        Bukkit.getScheduler().runTaskLater(RBWPlugin.getInstance(), () ->
+                guild.modifyMemberRoles(target, null, freeze).queue(), delayTicks);
 
         // Notify in the SS request channel
         Embed embed = new Embed(

--- a/src/main/java/me/zypj/rbw/commands/utilities/SSCloseCmd.java
+++ b/src/main/java/me/zypj/rbw/commands/utilities/SSCloseCmd.java
@@ -15,8 +15,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
 
 import java.util.Objects;
-import java.util.Timer;
-import java.util.TimerTask;
+import org.bukkit.Bukkit;
 
 public class SSCloseCmd extends Command {
     public SSCloseCmd(String command, String usage, String[] aliases, String description, CommandSubsystem subsystem) {
@@ -45,20 +44,15 @@ public class SSCloseCmd extends Command {
 
         msg.reply("<@" + ss.getTarget().getID() + ">").setEmbeds(embed.build()).queue();
 
-        TimerTask closingTask = new TimerTask() {
-            @Override
-            public void run() {
-                try {
-                    if (guild.getTextChannelById(ss.getChannelID()) != null) {
-                        Objects.requireNonNull(guild.getTextChannelById(ss.getChannelID())).delete().queue();
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
+        Bukkit.getScheduler().runTaskLater(RBWPlugin.getInstance(), () -> {
+            try {
+                if (guild.getTextChannelById(ss.getChannelID()) != null) {
+                    Objects.requireNonNull(guild.getTextChannelById(ss.getChannelID())).delete().queue();
                 }
+            } catch (Exception e) {
+                e.printStackTrace();
             }
-        };
-
-        new Timer().schedule(closingTask, 180 * 1000L);
+        }, 20L * 60 * 3);
 
         embed.setType(EmbedType.DEFAULT);
         embed.setTitle(ss.getTarget().getIgn() + " (" + ss.getTarget().getID() + ")");

--- a/src/main/java/me/zypj/rbw/instance/Game.java
+++ b/src/main/java/me/zypj/rbw/instance/Game.java
@@ -20,6 +20,7 @@ import net.dv8tion.jda.api.exceptions.ErrorHandler;
 import net.dv8tion.jda.api.requests.ErrorResponse;
 import org.bukkit.Bukkit;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -75,7 +76,7 @@ public class Game {
     @Getter
     private Member scoredBy; // this acts as voidedBy if game was voided
 
-    private TimerTask closingTask;
+    private BukkitTask closingTask;
 
     // IF THE GAME WAS SCORED
 
@@ -591,26 +592,21 @@ public class Game {
             closingTask.cancel();
         }
 
-        closingTask = new TimerTask() {
-            @Override
-            public void run() {
-                try {
-                    if (guild.getTextChannelById(channelID) != null) {
-                        Objects.requireNonNull(guild.getTextChannelById(channelID)).delete().queue();
-                    }
-                    if (guild.getVoiceChannelById(vc1ID) != null) {
-                        Objects.requireNonNull(guild.getVoiceChannelById(vc1ID)).delete().queue();
-                    }
-                    if (guild.getVoiceChannelById(vc2ID) != null) {
-                        Objects.requireNonNull(guild.getVoiceChannelById(vc2ID)).delete().queue();
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
+        closingTask = Bukkit.getScheduler().runTaskLater(RBWPlugin.getInstance(), () -> {
+            try {
+                if (guild.getTextChannelById(channelID) != null) {
+                    Objects.requireNonNull(guild.getTextChannelById(channelID)).delete().queue();
                 }
+                if (guild.getVoiceChannelById(vc1ID) != null) {
+                    Objects.requireNonNull(guild.getVoiceChannelById(vc1ID)).delete().queue();
+                }
+                if (guild.getVoiceChannelById(vc2ID) != null) {
+                    Objects.requireNonNull(guild.getVoiceChannelById(vc2ID)).delete().queue();
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
             }
-        };
-
-        new Timer().schedule(closingTask, timeSeconds * 1000L);
+        }, timeSeconds * 20L);
     }
 
     public void warpToMap(int triesMax) {

--- a/src/main/java/me/zypj/rbw/instance/GameMap.java
+++ b/src/main/java/me/zypj/rbw/instance/GameMap.java
@@ -4,8 +4,8 @@ import me.zypj.rbw.RBWPlugin;
 import me.zypj.rbw.instance.cache.MapCache;
 import com.tomkeuper.bedwars.api.arena.GameState;
 
-import java.util.Timer;
-import java.util.TimerTask;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitRunnable;
 
 public class GameMap {
 
@@ -27,9 +27,9 @@ public class GameMap {
 
         MapCache.initializeMap(name, this);
 
-        TimerTask checkTask = new TimerTask () {
+        new BukkitRunnable() {
             @Override
-            public void run () {
+            public void run() {
                 if (RBWPlugin.bedwarsAPI.getArenaUtil().getArenaByName(name) == null) {
                     cancel();
                     if (MapCache.containsMap(name))
@@ -39,9 +39,7 @@ public class GameMap {
 
                 MapCache.getMap(name).setArenaState(RBWPlugin.bedwarsAPI.getArenaUtil().getArenaByName(name).getStatus());
             }
-        };
-
-        new Timer().schedule(checkTask, 1000, 1000);
+        }.runTaskTimer(RBWPlugin.getInstance(), 20L, 20L);
     }
 
     public String getName() {

--- a/src/main/java/me/zypj/rbw/instance/LinkManager.java
+++ b/src/main/java/me/zypj/rbw/instance/LinkManager.java
@@ -1,5 +1,7 @@
 package me.zypj.rbw.instance;
 
+import me.zypj.rbw.RBWPlugin;
+import org.bukkit.Bukkit;
 import java.util.*;
 
 public class LinkManager {
@@ -19,15 +21,8 @@ public class LinkManager {
 
         links.put(ID, code);
 
-        TimerTask task = new TimerTask () {
-            @Override
-            public void run () {
-                links.remove(ID);
-            }
-        };
-
-        // 5 mins
-        new Timer().schedule(task, 1000 * 60 * 5);
+        Bukkit.getScheduler().runTaskLater(RBWPlugin.getInstance(), () ->
+                links.remove(ID), 20L * 60 * 5);
 
         return code;
     }

--- a/src/main/java/me/zypj/rbw/instance/Party.java
+++ b/src/main/java/me/zypj/rbw/instance/Party.java
@@ -5,8 +5,8 @@ import me.zypj.rbw.instance.cache.PartyCache;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
+import me.zypj.rbw.RBWPlugin;
+import org.bukkit.Bukkit;
 
 public class Party {
 
@@ -27,15 +27,11 @@ public class Party {
 
         invitedPlayers.add(invited);
 
-        TimerTask inviteExpiration = new TimerTask() {
-            @Override
-            public void run() {
-                if (invitedPlayers.contains(invited)) {
-                    invitedPlayers.remove(invited);
-                }
+        Bukkit.getScheduler().runTaskLater(RBWPlugin.getInstance(), () -> {
+            if (invitedPlayers.contains(invited)) {
+                invitedPlayers.remove(invited);
             }
-        };
-        new Timer().schedule(inviteExpiration, Integer.parseInt(Config.getValue("invite-expiration")) * 60 * 1000L);
+        }, Integer.parseInt(Config.getValue("invite-expiration")) * 60L * 20L);
     }
 
     public void disband() {

--- a/src/main/java/me/zypj/rbw/instance/Queue.java
+++ b/src/main/java/me/zypj/rbw/instance/Queue.java
@@ -12,8 +12,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
 
 public class Queue {
 
@@ -24,7 +25,7 @@ public class Queue {
     private List<Player> players;
     private double eloMultiplier;
 
-    TimerTask queueTimer;
+    BukkitTask queueTimer;
 
     public Queue(String ID) {
         this.ID = ID;
@@ -48,7 +49,7 @@ public class Queue {
 
         Queue q = this;
 
-        queueTimer = new TimerTask() {
+        queueTimer = new BukkitRunnable() {
             @Override
             public void run() {
                 try {
@@ -134,9 +135,7 @@ public class Queue {
                     e.printStackTrace();
                 }
             }
-        };
-
-        new Timer().schedule(queueTimer, 0L, 7000L);
+        }.runTaskTimer(RBWPlugin.getInstance(), 0L, 140L);
     }
 
     public void addPlayer(Player player) {


### PR DESCRIPTION
## Summary
- use Bukkit scheduler to replace `Timer` usages
- ensure delayed tasks run via Bukkit

## Testing
- `sh gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_6849673ec9a8832d9270f4169367faa0