### PR TITLE
Async JDA initialization

### DIFF
--- a/src/main/java/me/zypj/rbw/listener/BotReadyListener.java
+++ b/src/main/java/me/zypj/rbw/listener/BotReadyListener.java
@@ -1,0 +1,13 @@
+package me.zypj.rbw.listener;
+
+import me.zypj.rbw.RBWPlugin;
+import net.dv8tion.jda.api.events.session.ReadyEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+
+public class BotReadyListener extends ListenerAdapter {
+    @Override
+    public void onReady(@NotNull ReadyEvent event) {
+        RBWPlugin.getInstance().onJdaReady();
+    }
+}


### PR DESCRIPTION
## Summary
- build JDA asynchronously
- add BotReadyListener to notify plugin when JDA is ready
- kick off initialization when JDA is ready instead of delaying

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68496b783890832d83a0624f500bf64e