### PR TITLE
Refactor DB managers to use PreparedStatement

### DIFF
--- a/src/main/java/me/zypj/rbw/database/SQLClanManager.java
+++ b/src/main/java/me/zypj/rbw/database/SQLClanManager.java
@@ -8,18 +8,20 @@ import java.sql.SQLException;
 public class SQLClanManager {
 
     public static void createClan(String name, String leader) {
-        SQLite.updateData("INSERT INTO clans(name, leader, members, reputation, clanXP, clanLevel, wins, losses, private, eloJoinReq, description)" +
-                " VALUES('" + name + "'," +
-                "'" + leader + "'," +
-                "'" + leader + "'," +
-                0 + "," +
-                0 + "," +
-                0 + "," +
-                0 + "," +
-                0 + "," +
-                "'true'," +
-                0 + "," +
-                "'A newly created RBW clan');");
+        String sql = "INSERT INTO clans(name, leader, members, reputation, clanXP, clanLevel, wins, losses, private, eloJoinReq, description)"
+                + " VALUES(?,?,?,?,?,?,?,?,?,?,?)";
+        SQLite.updateData(sql,
+                name,
+                leader,
+                leader,
+                0,
+                0,
+                0,
+                0,
+                0,
+                "true",
+                0,
+                "A newly created RBW clan");
     }
 
     public static int getClanSize() {
@@ -34,26 +36,33 @@ public class SQLClanManager {
     }
 
     public static void updateReputation(String name) {
-        SQLite.updateData("UPDATE clans SET reputation = '" + ClanCache.getClan(name).getReputation() + "' WHERE name='" + name + "';");
+        String sql = "UPDATE clans SET reputation = ? WHERE name=?";
+        SQLite.updateData(sql, ClanCache.getClan(name).getReputation(), name);
     }
 
     public static void updateXP(String name) {
-        SQLite.updateData("UPDATE clans SET xp = '" + ClanCache.getClan(name).getXp() + "' WHERE name='" + name + "';");
+        String sql = "UPDATE clans SET xp = ? WHERE name=?";
+        SQLite.updateData(sql, ClanCache.getClan(name).getXp(), name);
     }
 
     public static void updateLevel(String name) {
-        SQLite.updateData("UPDATE clans SET level = '" + ClanCache.getClan(name).getLevel().getLevel() + "' WHERE name='" + name + "';");
+        String sql = "UPDATE clans SET level = ? WHERE name=?";
+        SQLite.updateData(sql, ClanCache.getClan(name).getLevel().getLevel(), name);
     }
 
     public static void updatePrivate(String name) {
-        SQLite.updateData("UPDATE clans SET private = '" + ClanCache.getClan(name).isPrivate() + "' WHERE name='" + name + "';");
+        String sql = "UPDATE clans SET private = ? WHERE name=?";
+        SQLite.updateData(sql, ClanCache.getClan(name).isPrivate(), name);
     }
 
     public static void updateEloJoinReq(String name) {
-        SQLite.updateData("UPDATE clans SET eloJoinReq = '" + ClanCache.getClan(name).getEloJoinReq() + "' WHERE name='" + name + "';");
+        String sql = "UPDATE clans SET eloJoinReq = ? WHERE name=?";
+        SQLite.updateData(sql, ClanCache.getClan(name).getEloJoinReq(), name);
     }
 
     public static void updateDescription(String name) {
-        SQLite.updateData("UPDATE clans SET description = '" + ClanCache.getClan(name).getDescription() + "' WHERE name='" + name + "';");
+        String sql = "UPDATE clans SET description = ? WHERE name=?";
+        SQLite.updateData(sql, ClanCache.getClan(name).getDescription(), name);
     }
 }
+

--- a/src/main/java/me/zypj/rbw/database/SQLClanWars.java
+++ b/src/main/java/me/zypj/rbw/database/SQLClanWars.java
@@ -10,31 +10,27 @@ import java.util.List;
 public class SQLClanWars {
 
     public static void createWar(int playersPerTeam, int minClans, int maxClans, int xpPerWin, int goldPerWin) {
-        SQLite.updateData("INSERT INTO clanwars(playersPerTeam, minClans, maxClans, xpPerWin, goldPerWin, active)" +
-                " VALUES(" + playersPerTeam + "," +
-                minClans + "," +
-                maxClans + "," +
-                xpPerWin + "," +
-                goldPerWin + "," +
-                "'true');");
+        String sql = "INSERT INTO clanwars(playersPerTeam, minClans, maxClans, xpPerWin, goldPerWin, active) VALUES(?,?,?,?,?,?)";
+        SQLite.updateData(sql, playersPerTeam, minClans, maxClans, xpPerWin, goldPerWin, "true");
     }
 
     public static void registerClan(String warId, String clanName) {
-        SQLite.updateData("INSERT INTO clanwar_registrations(warId, clanName) VALUES(" +
-                "'" + warId + "'," +
-                "'" + clanName + "');");
+        String sql = "INSERT INTO clanwar_registrations(warId, clanName) VALUES(?,?)";
+        SQLite.updateData(sql, warId, clanName);
     }
 
     public static void unregisterClan(String warId, String clanName) {
-        SQLite.updateData("DELETE FROM clanwar_registrations WHERE warId='" + warId + "' AND clanName='" + clanName + "';");
+        String sql = "DELETE FROM clanwar_registrations WHERE warId=? AND clanName=?";
+        SQLite.updateData(sql, warId, clanName);
     }
 
     public static void updateWarStatus(String warId, boolean isActive) {
-        SQLite.updateData("UPDATE clanwars SET active = '" + isActive + "' WHERE warId='" + warId + "';");
+        String sql = "UPDATE clanwars SET active = ? WHERE warId=?";
+        SQLite.updateData(sql, isActive, warId);
     }
 
     public static List<String> getRegisteredClans(String warId) {
-        ResultSet resultSet = SQLite.queryData("SELECT clanName FROM clanwar_registrations WHERE warId='" + warId + "';");
+        ResultSet resultSet = SQLite.queryData("SELECT clanName FROM clanwar_registrations WHERE warId=?", warId);
         List<String> clans = new ArrayList<>();
         try {
             while (resultSet.next()) {
@@ -47,7 +43,7 @@ public class SQLClanWars {
     }
 
     public static ClanWar getWar(String warId) {
-        ResultSet resultSet = SQLite.queryData("SELECT * FROM clanwars WHERE warId='" + warId + "';");
+        ResultSet resultSet = SQLite.queryData("SELECT * FROM clanwars WHERE warId=?", warId);
         try {
             if (resultSet.next()) {
                 int playersPerTeam = resultSet.getInt("playersPerTeam");
@@ -65,3 +61,4 @@ public class SQLClanWars {
         return null;
     }
 }
+

--- a/src/main/java/me/zypj/rbw/database/SQLGameManager.java
+++ b/src/main/java/me/zypj/rbw/database/SQLGameManager.java
@@ -10,20 +10,18 @@ import java.sql.SQLException;
 public class SQLGameManager {
 
     public static void createGame(Game g) {
-        String team1 = "";
-        String team2 = "";
-
-        SQLite.updateData("INSERT INTO games(number, state, casual, map, channelID, vc1ID, vc2ID, queueID, team1, team2)" +
-                " VALUES(" + g.getNumber() + "," +
-                "'" + g.getState().toString().toUpperCase() + "'," +
-                "'" + g.isCasual() + "'," +
-                "'" + (g.getMap() == null ? null : g.getMap().getName()) + "'," +
-                "'" + g.getChannelID() + "'," +
-                "'" + g.getVC1ID() + "'," +
-                "'" + g.getVC2ID() + "'," +
-                "'" + g.getQueue().getID() + "'," +
-                "'" + team1 + "'," +
-                "'" + team2 + "');");
+        String sql = "INSERT INTO games(number, state, casual, map, channelID, vc1ID, vc2ID, queueID, team1, team2) VALUES(?,?,?,?,?,?,?,?,?,?)";
+        SQLite.updateData(sql,
+                g.getNumber(),
+                g.getState().toString().toUpperCase(),
+                String.valueOf(g.isCasual()),
+                g.getMap() == null ? null : g.getMap().getName(),
+                g.getChannelID(),
+                g.getVC1ID(),
+                g.getVC2ID(),
+                g.getQueue().getID(),
+                "",
+                "");
     }
 
     public static void updateGame(Game g) {
@@ -44,25 +42,27 @@ public class SQLGameManager {
             }
         }
 
-        ResultSet resultSet = SQLite.queryData("SELECT EXISTS(SELECT 1 FROM games WHERE number='" + g.getNumber() + "');");
+        ResultSet resultSet = SQLite.queryData("SELECT EXISTS(SELECT 1 FROM games WHERE number=?)", g.getNumber());
         try {
-            if (resultSet.getInt(1) == 1)
-                SQLite.updateData("DELETE FROM games WHERE number = " + g.getNumber() + ";");
+            if (resultSet.getInt(1) == 1) {
+                SQLite.updateData("DELETE FROM games WHERE number=?", g.getNumber());
+            }
         } catch (SQLException e) {
             e.printStackTrace();
         }
 
-        SQLite.updateData("INSERT INTO games(number, state, casual, map, channelID, vc1ID, vc2ID, queueID, team1, team2)" +
-                " VALUES(" + g.getNumber() + "," +
-                "'" + g.getState().toString().toUpperCase() + "'," +
-                "'" + g.isCasual() + "'," +
-                "'" + g.getMap().getName() + "'," +
-                "'" + g.getChannelID() + "'," +
-                "'" + g.getVC1ID() + "'," +
-                "'" + g.getVC2ID() + "'," +
-                "'" + g.getQueue().getID() + "'," +
-                "'" + team1 + "'," +
-                "'" + team2 + "');");
+        String sql = "INSERT INTO games(number, state, casual, map, channelID, vc1ID, vc2ID, queueID, team1, team2) VALUES(?,?,?,?,?,?,?,?,?,?)";
+        SQLite.updateData(sql,
+                g.getNumber(),
+                g.getState().toString().toUpperCase(),
+                String.valueOf(g.isCasual()),
+                g.getMap().getName(),
+                g.getChannelID(),
+                g.getVC1ID(),
+                g.getVC2ID(),
+                g.getQueue().getID(),
+                team1.toString(),
+                team2.toString());
     }
 
     public static int getGameSize() {
@@ -77,15 +77,18 @@ public class SQLGameManager {
     }
 
     public static void updateState(int number) {
-        SQLite.updateData("UPDATE games SET state = '" + GameCache.getGame(number).getState().toString().toUpperCase() + "' WHERE number=" + number + ";");
+        String sql = "UPDATE games SET state = ? WHERE number=?";
+        SQLite.updateData(sql, GameCache.getGame(number).getState().toString().toUpperCase(), number);
     }
 
     public static void updateMvp(int number) {
-        SQLite.updateData("UPDATE games SET mvp = '" + GameCache.getGame(number).getMvp().getIgn() + "' WHERE number=" + number + ";");
+        String sql = "UPDATE games SET mvp = ? WHERE number=?";
+        SQLite.updateData(sql, GameCache.getGame(number).getMvp().getIgn(), number);
     }
 
     public static void updateScoredBy(int number) {
-        SQLite.updateData("UPDATE games SET scoredBy = '" + GameCache.getGame(number).getScoredBy().getId() + "' WHERE number=" + number + ";");
+        String sql = "UPDATE games SET scoredBy = ? WHERE number=?";
+        SQLite.updateData(sql, GameCache.getGame(number).getScoredBy().getId(), number);
     }
 
     public static void updateEloGain(int number) {
@@ -108,8 +111,8 @@ public class SQLGameManager {
             }
         }
 
-        SQLite.updateData("UPDATE games SET team1 = '" + team1 + "' WHERE number=" + number + ";");
-        SQLite.updateData("UPDATE games SET team2 = '" + team2 + "' WHERE number=" + number + ";");
+        SQLite.updateData("UPDATE games SET team1 = ? WHERE number=?", team1.toString(), number);
+        SQLite.updateData("UPDATE games SET team2 = ? WHERE number=?", team2.toString(), number);
     }
 
     public static void removeEloGain(int number) {
@@ -132,7 +135,8 @@ public class SQLGameManager {
             }
         }
 
-        SQLite.updateData("UPDATE games SET team1 = '" + team1 + "' WHERE number=" + number + ";");
-        SQLite.updateData("UPDATE games SET team2 = '" + team2 + "' WHERE number=" + number + ";");
+        SQLite.updateData("UPDATE games SET team1 = ? WHERE number=?", team1.toString(), number);
+        SQLite.updateData("UPDATE games SET team2 = ? WHERE number=?", team2.toString(), number);
     }
 }
+

--- a/src/main/java/me/zypj/rbw/database/SQLPlayerManager.java
+++ b/src/main/java/me/zypj/rbw/database/SQLPlayerManager.java
@@ -12,34 +12,35 @@ import java.time.format.DateTimeFormatter;
 public class SQLPlayerManager {
 
     public static void createPlayer(String ID, String ign) {
-        SQLite.updateData("INSERT INTO players(discordID, ign, elo, peakElo, wins, losses, winStreak, lossStreak, highestWS, highestLS," +
-                "mvp, kills, deaths, strikes, scored, gold, level, xp, theme, ownedThemes, isBanned, bannedTill)" +
-                " VALUES('" + ID + "'," +
-                "'" + ign + "'," +
-                Config.getValue("starting-elo") + "," + // elo
-                Config.getValue("starting-elo") + "," + // peak elo
-                "0," + // wins
-                "0," + // losses
-                "0," + // ws
-                "0," + // ls
-                "0," + // highest ws
-                "0," + // highest ls
-                "0," + // mvp
-                "0," + // kills
-                "0," + // deaths0
-                "0," + // strikes
-                "0," + // scored
-                "0," + // gold
-                "0," + // level
-                "0," + // xp
-                "'default'," + // theme
-                "'default'," + // owned themes
-                "'false'," + // is banned
-                "'');"); // banned till
+        String sql = "INSERT INTO players(discordID, ign, elo, peakElo, wins, losses, winStreak, lossStreak, highestWS, highestLS," +
+                " mvp, kills, deaths, strikes, scored, gold, level, xp, theme, ownedThemes, isBanned, bannedTill)" +
+                " VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+        SQLite.updateData(sql,
+                ID,
+                ign,
+                Integer.parseInt(Config.getValue("starting-elo")),
+                Integer.parseInt(Config.getValue("starting-elo")),
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                "default",
+                "default",
+                "false",
+                "");
     }
 
     public static void unregisterPlayer(String ID) {
-        SQLite.updateData("DELETE FROM players WHERE discordID = '" + ID + "';");
+        SQLite.updateData("DELETE FROM players WHERE discordID = ?", ID);
     }
 
     public static int getPlayerSize() {
@@ -54,7 +55,7 @@ public class SQLPlayerManager {
     }
 
     public static boolean isRegistered(String ID) {
-        ResultSet resultSet = SQLite.queryData("SELECT EXISTS(SELECT 1 FROM players WHERE discordID='" + ID + "');");
+        ResultSet resultSet = SQLite.queryData("SELECT EXISTS(SELECT 1 FROM players WHERE discordID=?)", ID);
 
         try {
             if (resultSet.getInt(1) == 1)
@@ -67,75 +68,75 @@ public class SQLPlayerManager {
     }
 
     public static void updateIgn(String ID) {
-        SQLite.updateData("UPDATE players SET ign = '" + PlayerCache.getPlayer(ID).getIgn() + "' WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET ign = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getIgn(), ID);
     }
 
     public static void updateElo(String ID) {
-        SQLite.updateData("UPDATE players SET elo = " + PlayerCache.getPlayer(ID).getElo() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET elo = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getElo(), ID);
     }
 
     public static void updatePeakElo(String ID) {
-        SQLite.updateData("UPDATE players SET peakElo = " + PlayerCache.getPlayer(ID).getPeakElo() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET peakElo = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getPeakElo(), ID);
     }
 
     public static void updateWins(String ID) {
-        SQLite.updateData("UPDATE players SET wins = " + PlayerCache.getPlayer(ID).getWins() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET wins = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getWins(), ID);
     }
 
     public static void updateLosses(String ID) {
-        SQLite.updateData("UPDATE players SET losses = " + PlayerCache.getPlayer(ID).getLosses() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET losses = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getLosses(), ID);
     }
 
     public static void updateWinStreak(String ID) {
-        SQLite.updateData("UPDATE players SET winStreak = " + PlayerCache.getPlayer(ID).getWinStreak() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET winStreak = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getWinStreak(), ID);
     }
 
     public static void updateLossStreak(String ID) {
-        SQLite.updateData("UPDATE players SET lossStreak = " + PlayerCache.getPlayer(ID).getLossStreak() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET lossStreak = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getLossStreak(), ID);
     }
 
     public static void updateHighestWS(String ID) {
-        SQLite.updateData("UPDATE players SET highestWS = " + PlayerCache.getPlayer(ID).getHighestWS() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET highestWS = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getHighestWS(), ID);
     }
 
     public static void updateHighestLS(String ID) {
-        SQLite.updateData("UPDATE players SET highestLS = " + PlayerCache.getPlayer(ID).getHighestLS() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET highestLS = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getHighestLS(), ID);
     }
 
     public static void updateMvp(String ID) {
-        SQLite.updateData("UPDATE players SET mvp = " + PlayerCache.getPlayer(ID).getMvp() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET mvp = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getMvp(), ID);
     }
 
     public static void updateKills(String ID) {
-        SQLite.updateData("UPDATE players SET kills = " + PlayerCache.getPlayer(ID).getKills() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET kills = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getKills(), ID);
     }
 
     public static void updateDeaths(String ID) {
-        SQLite.updateData("UPDATE players SET deaths = " + PlayerCache.getPlayer(ID).getDeaths() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET deaths = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getDeaths(), ID);
     }
 
     public static void updateStrikes(String ID) {
-        SQLite.updateData("UPDATE players SET strikes = " + PlayerCache.getPlayer(ID).getStrikes() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET strikes = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getStrikes(), ID);
     }
 
     public static void updateScored(String ID) {
-        SQLite.updateData("UPDATE players SET scored = " + PlayerCache.getPlayer(ID).getScored() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET scored = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getScored(), ID);
     }
 
     public static void updateGold(String ID) {
-        SQLite.updateData("UPDATE players SET gold = " + PlayerCache.getPlayer(ID).getGold() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET gold = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getGold(), ID);
     }
 
     public static void updateLevel(String ID) {
-        SQLite.updateData("UPDATE players SET level = " + PlayerCache.getPlayer(ID).getLevel().getLevel() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET level = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getLevel().getLevel(), ID);
     }
 
     public static void updateXP(String ID) {
-        SQLite.updateData("UPDATE players SET xp = " + PlayerCache.getPlayer(ID).getXp() + " WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET xp = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getXp(), ID);
     }
 
     public static void updateTheme(String ID) {
-        SQLite.updateData("UPDATE players SET theme = '" + PlayerCache.getPlayer(ID).getTheme().getName() + "' WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET theme = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getTheme().getName(), ID);
     }
 
     public static void updateOwnedThemes(String ID) {
@@ -149,11 +150,11 @@ public class SQLPlayerManager {
             }
         }
 
-        SQLite.updateData("UPDATE players SET ownedThemes = '" + themes + "' WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET ownedThemes = ? WHERE discordID=?", themes.toString(), ID);
     }
 
     public static void updateIsBanned(String ID) {
-        SQLite.updateData("UPDATE players SET isBanned = '" + PlayerCache.getPlayer(ID).isBanned() + "' WHERE discordID='" + ID + "';");
+        SQLite.updateData("UPDATE players SET isBanned = ? WHERE discordID=?", PlayerCache.getPlayer(ID).isBanned(), ID);
     }
 
     public static void updateBannedTill(String ID) {
@@ -163,9 +164,9 @@ public class SQLPlayerManager {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
             String bannedTill = formatter.format(player.getBannedTill());
 
-            SQLite.updateData("UPDATE players SET bannedTill = '" + bannedTill + "' WHERE discordID='" + ID + "';");
+            SQLite.updateData("UPDATE players SET bannedTill = ? WHERE discordID=?", bannedTill, ID);
         } else {
-            SQLite.updateData("UPDATE players SET bannedTill = '' WHERE discordID='" + ID + "';");
+            SQLite.updateData("UPDATE players SET bannedTill = '' WHERE discordID=?", ID);
         }
     }
 
@@ -173,9 +174,10 @@ public class SQLPlayerManager {
         Player player = PlayerCache.getPlayer(ID);
 
         if (player.isBanned()) {
-            SQLite.updateData("UPDATE players SET banReason = '" + PlayerCache.getPlayer(ID).getBanReason() + "' WHERE discordID='" + ID + "';");
+            SQLite.updateData("UPDATE players SET banReason = ? WHERE discordID=?", PlayerCache.getPlayer(ID).getBanReason(), ID);
         } else {
-            SQLite.updateData("UPDATE players SET banReason = '' WHERE discordID='" + ID + "';");
+            SQLite.updateData("UPDATE players SET banReason = '' WHERE discordID=?", ID);
         }
     }
 }
+

--- a/src/main/java/me/zypj/rbw/database/SQLUtilsManager.java
+++ b/src/main/java/me/zypj/rbw/database/SQLUtilsManager.java
@@ -8,13 +8,8 @@ import java.sql.SQLException;
 public class SQLUtilsManager {
 
     public static void createRank(String ID, String startingElo, String endingElo, String winElo, String loseElo, String mvpElo) {
-        SQLite.updateData("INSERT INTO ranks(discordID, startingElo, endingElo, winElo, loseElo, mvpElo)" +
-                " VALUES('" + ID + "'," +
-                startingElo + "," +
-                endingElo + "," +
-                winElo + "," +
-                loseElo + "," +
-                mvpElo + ");");
+        String sql = "INSERT INTO ranks(discordID, startingElo, endingElo, winElo, loseElo, mvpElo) VALUES(?,?,?,?,?,?)";
+        SQLite.updateData(sql, ID, startingElo, endingElo, winElo, loseElo, mvpElo);
     }
 
     public static int getRankSize() {
@@ -29,12 +24,8 @@ public class SQLUtilsManager {
     }
 
     public static void createQueue(String ID, int playersEachTeam, PickingMode pickingMode, boolean casual) {
-        SQLite.updateData("INSERT INTO queues(discordID, playersEachTeam, pickingMode, casual, eloMultiplier)" +
-                " VALUES('" + ID + "'," +
-                playersEachTeam + "," +
-                "'" + pickingMode.toString().toUpperCase() + "'," +
-                "'" + casual + "'," +
-                "1.0);");
+        String sql = "INSERT INTO queues(discordID, playersEachTeam, pickingMode, casual, eloMultiplier) VALUES(?,?,?,?,?)";
+        SQLite.updateData(sql, ID, playersEachTeam, pickingMode.toString().toUpperCase(), String.valueOf(casual), 1.0);
     }
 
     public static int getQueueSize() {
@@ -48,3 +39,4 @@ public class SQLUtilsManager {
         return 0;
     }
 }
+

--- a/src/main/java/me/zypj/rbw/database/SQLite.java
+++ b/src/main/java/me/zypj/rbw/database/SQLite.java
@@ -12,6 +12,10 @@ public class SQLite {
 
     private static Connection connection;
 
+    public static Connection getConnection() {
+        return connection;
+    }
+
     public static void connect() {
         connection = null;
         try {
@@ -47,6 +51,17 @@ public class SQLite {
         }
     }
 
+    public static void updateData(String sql, Object... params) {
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            for (int i = 0; i < params.length; i++) {
+                ps.setObject(i + 1, params[i]);
+            }
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+
     public static ResultSet queryData(String sql) {
         ResultSet resultSet = null;
         try {
@@ -56,6 +71,19 @@ public class SQLite {
             e.printStackTrace();
         }
         return resultSet;
+    }
+
+    public static ResultSet queryData(String sql, Object... params) {
+        try {
+            PreparedStatement ps = connection.prepareStatement(sql);
+            for (int i = 0; i < params.length; i++) {
+                ps.setObject(i + 1, params[i]);
+            }
+            return ps.executeQuery();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     public static void closeResultSet(ResultSet resultSet) {


### PR DESCRIPTION
## Summary
- add connection accessor in `SQLite`
- add parameterized query helpers
- replace string-concatenated SQL with PreparedStatement usage in all database manager classes

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6849b09becf4832da77584b0eb4a22cf