### PR TITLE
Add cleanup listener for Embed pages

### DIFF
--- a/src/main/java/me/zypj/rbw/RBWPlugin.java
+++ b/src/main/java/me/zypj/rbw/RBWPlugin.java
@@ -134,7 +134,7 @@ public final class RBWPlugin extends JavaPlugin {
                         .setChunkingFilter(ChunkingFilter.ALL)
                         .setMemberCachePolicy(MemberCachePolicy.ALL)
                         .enableIntents(GatewayIntent.GUILD_MEMBERS, GatewayIntent.GUILD_MESSAGES)
-                        .addEventListeners(new CommandManager(), new PagesEvents(), new QueueJoin(), new ServerJoin(), new PartyInviteButton(), new BotReadyListener())
+                        .addEventListeners(new CommandManager(), new PagesEvents(), new QueueJoin(), new ServerJoin(), new PartyInviteButton(), new BotReadyListener(), new EmbedCleanupListener())
                         .build();
             } catch (Exception e) {
                 e.printStackTrace();

--- a/src/main/java/me/zypj/rbw/instance/Embed.java
+++ b/src/main/java/me/zypj/rbw/instance/Embed.java
@@ -14,14 +14,15 @@ import java.awt.*;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Setter
 public class Embed {
 
-    public static HashMap<String, List<Embed>> embedPages = new HashMap<>();
+    public static Map<String, List<Embed>> embedPages = new ConcurrentHashMap<>();
 
     private int pages;
     private int currentPage = 0;

--- a/src/main/java/me/zypj/rbw/listener/EmbedCleanupListener.java
+++ b/src/main/java/me/zypj/rbw/listener/EmbedCleanupListener.java
@@ -1,0 +1,16 @@
+package me.zypj.rbw.listener;
+
+import me.zypj.rbw.instance.Embed;
+import net.dv8tion.jda.api.events.message.MessageDeleteEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Removes stored embed pages when the original message is deleted.
+ */
+public class EmbedCleanupListener extends ListenerAdapter {
+    @Override
+    public void onMessageDelete(@NotNull MessageDeleteEvent event) {
+        Embed.embedPages.remove(event.getMessageId());
+    }
+}


### PR DESCRIPTION
## Summary
- maintain a thread-safe map for paged embeds
- remove paged embeds when their message gets deleted
- hook the new listener into the Discord bot

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6849b372d5d4832d8d141e3d2aae0d5a